### PR TITLE
Fix parsing errors when unicode in a template loaded from text

### DIFF
--- a/liquid/stream.py
+++ b/liquid/stream.py
@@ -50,8 +50,8 @@ class LiquidStream:
 		"""
 		if self.stream.closed:
 			return 0
-		else:
-			return self.stream.tell()
+
+		return self.stream.tell()
 
 	@staticmethod
 	def from_file(path):

--- a/liquid/stream.py
+++ b/liquid/stream.py
@@ -105,7 +105,6 @@ class LiquidStream:
 		@returns:
 			str: the next character
 		"""
-		self._last = self.cursor
 		ret = self.stream.read(1)
 		return ret
 

--- a/liquid/stream.py
+++ b/liquid/stream.py
@@ -114,16 +114,6 @@ class LiquidStream:
 		"""
 		self.stream.seek(0)
 
-	def seek(self, pos):
-		"""
-		Seek to a particular position in the stream
-
-		:param pos: The position in the stream to seek to
-
-		:return: The new position in the stream
-		"""
-		return self.stream.seek(pos)
-
 	def eos(self):
 		"""
 		Tell if the stream is ended
@@ -252,7 +242,7 @@ class LiquidStream:
 				return ret, matched_candidate
 			if char == escape:
 				if matched_candidate and escape not in matrix[len(matched_candidate)]:
-					self.seek(last)
+					self.stream.seek(last)
 					return ret, matched_candidate
 				escape_flags = not escape_flags
 				ret += matched_chars + char
@@ -268,7 +258,7 @@ class LiquidStream:
 					quote_flags[quote_index[char]] = not quote_flags[quote_index[char]]
 				if sum(wrap_flags) > 0 or any(quote_flags):
 					if matched_candidate:
-						self.seek(last)
+						self.stream.seek(last)
 						return ret, matched_candidate
 					ret += matched_chars + char
 					matched_chars = ''
@@ -288,7 +278,7 @@ class LiquidStream:
 								return ret, matched_chars
 
 					elif matched_candidate:
-						self.seek(last)
+						self.stream.seek(last)
 						return ret, matched_candidate
 					else:
 						ret += matched_chars + char

--- a/liquid/stream.py
+++ b/liquid/stream.py
@@ -39,7 +39,13 @@ class LiquidStream:
 			stream (Stream): A python stream
 		"""
 		self.stream = stream
-		self.cursor = stream.tell()
+
+	@property
+	def cursor(self):
+		if self.stream.closed:
+			return 0
+		else:
+			return self.stream.tell()
 
 	@staticmethod
 	def from_file(path):
@@ -94,22 +100,19 @@ class LiquidStream:
 			str: the next character
 		"""
 		ret = self.stream.read(1)
-		self.cursor = self.stream.tell()
 		return ret
 
 	def back(self):
 		"""
 		Put cursor 1-character back
 		"""
-		self.cursor -= 1
-		self.stream.seek(self.cursor)
+		self.stream.seek(self.cursor - 1)
 
 	def rewind(self):
 		"""
 		Rewind the stream
 		"""
 		self.stream.seek(0)
-		self.cursor = 0
 
 	def eos(self):
 		"""
@@ -120,8 +123,7 @@ class LiquidStream:
 		nchar = self.next()
 		if not nchar:
 			return True
-		self.cursor -= 1
-		self.stream.seek(self.cursor)
+		self.stream.seek(self.cursor - 1)
 		return False
 
 	def dump(self):

--- a/liquid/stream.py
+++ b/liquid/stream.py
@@ -94,7 +94,7 @@ class LiquidStream:
 			str: the next character
 		"""
 		ret = self.stream.read(1)
-		self.cursor += len(ret.encode('utf-8'))
+		self.cursor = self.stream.tell()
 		return ret
 
 	def back(self):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -472,5 +472,13 @@ def test_issue9(HERE, debug):
 	liq = Liquid('{%% assign foo = "test" %%}{%% include %s/templates/include_issue9.liq %%}' % HERE)
 	assert liq.render() == 'test\nAccented character "ì" for testing\ntest'
 
+
 def test_unicode(HERE, debug):
 	assert Liquid(from_file = '%s/templates/include_issue9.liq' % HERE).render(foo = 'bar') == 'bar\nAccented character "ì" for testing\nbar'
+
+
+def test_unicode_string(debug):
+	template = """{{foo}}
+Accented character "ì" for testing
+{{foo}}"""
+	assert Liquid(template).render(foo = 'bar') == 'bar\nAccented character "ì" for testing\nbar'

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -55,9 +55,6 @@ def test_stream_init(tmp_path):
 	assert stm.next() == 'b'
 	assert not stm.eos()
 	assert stm.next() == 'c'
-	stm.back()
-	assert not stm.eos()
-	assert stm.next() == 'c'
 	assert stm.eos()
 	assert stm.next() == ''
 

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -10,6 +10,16 @@ from liquid import stream
 def test_words_to_matrix(words, expected):
 	assert stream.words_to_matrix(words) == expected
 
+
+def test_stream_unicode():
+	stm = stream.LiquidStream.from_string('abìcd')
+	assert stm.next() == 'a'
+	assert stm.next() == 'b'
+	assert stm.next() == 'ì'
+	assert stm.next() == 'c'
+	assert stm.next() == 'd'
+
+
 def test_stream_init(tmp_path):
 	string = io.StringIO('abc')
 	stm = stream.LiquidStream(string)
@@ -84,6 +94,25 @@ def test_until_until1():
 	string = stream.LiquidStream.from_string('mark: special job{{job.index}}" > {{job.outdir}}\\/job.report.data.yaml')
 	leading, tag = string.until(['{{', '{{-'], wraps = [], quotes = [])
 	assert leading == 'mark: special job'
+	assert tag == '{{'
+	leading, tag = string.until(['}}', '-}}'])
+	assert leading == 'job.index'
+	assert tag == '}}'
+	leading, tag = string.until(['{{', '{{-'], wraps = [], quotes = [])
+	assert leading == '" > '
+	assert tag == '{{'
+	leading, tag = string.until(['}}', '-}}'])
+	assert leading == 'job.outdir'
+	assert tag == '}}'
+	leading, tag = string.until(['{{', '{{-'], wraps = [], quotes = [])
+	assert leading == '\\/job.report.data.yaml'
+	assert tag == None
+
+
+def test_until_until_unicode():
+	string = stream.LiquidStream.from_string('mark: specìal job{{job.index}}" > {{job.outdir}}\\/job.report.data.yaml')
+	leading, tag = string.until(['{{', '{{-'], wraps = [], quotes = [])
+	assert leading == 'mark: specìal job'
 	assert tag == '{{'
 	leading, tag = string.until(['}}', '-}}'])
 	assert leading == 'job.index'


### PR DESCRIPTION
Templates loaded directly from a string that had unicode characters in them were failing to parse for me, because of what appeared to be differences in the way file-based text streams and StringIO-based streams handle seeking.

Delegating to `tell()` to let the underlying stream dictate the position of `cursor` after reading a character seemed to do the trick.