### PR TITLE
changed python-varname to just varname

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ poetry.lock
 *.bak
 
 .vscode
+.idea

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ include = "liquid"
 python = "^3.6"
 diot = "*"
 lark-parser = "^0.8"
-python-varname = "*"
+varname = "*"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"


### PR DESCRIPTION
The pyproject.toml file references a dependency that has moved.

`python-varname` -> `varname`