### PR TITLE
Include tests in tarball

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/pwwang/liquidpy"
 repository = "https://github.com/pwwang/liquidpy"
-include = ["liquid/tags/grammar.lark", "liquid/python/tags/grammar.lark"]
+include = ["liquid/tags/grammar.lark", "liquid/python/tags/grammar.lark", "tests/"]
 
 [[tool.poetry.packages]]
 include = "liquid"


### PR DESCRIPTION
This PR updates `pyproject.toml` to `include` the `tests/` directory in the tarball produced by `poetry build`. This allows downstream packagers (e.g. conda) to use the tests to validate the build.