### PR TITLE
✨ Add regex_replace filter

### DIFF
--- a/liquid/filters.py
+++ b/liquid/filters.py
@@ -232,6 +232,30 @@ def remove_first(base, string):
     return base.replace(string, '', 1)
 
 @filter_manager.register
+def regex_replace(base, regex, replace="", case_sensitive=False, count=0):
+    # type: (str, str, str, bool, int) -> str
+    """Replace matching regex pattern"""
+    import re
+
+    if not isinstance(base, str):
+        return base
+    if case_sensitive:
+        return re.sub(
+            pattern=regex,
+            repl=replace,
+            string=base,
+            count=count,
+        )
+    return re.sub(
+        pattern=regex,
+        repl=replace,
+        string=base,
+        count=count,
+        flags=re.IGNORECASE,
+    )
+
+
+@filter_manager.register
 def replace_first(base, old, new):
     """Replace the first substring with new string"""
     return base.replace(old, new, 1)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -130,6 +130,18 @@ from liquid import Liquid
     ("ants, bugs, bees, bugs, ants",
      'split: ", " | uniq | join: ", "',
      "ants, bugs, bees"),
+    ("And the people bowed and prayed To the neon god they made",
+     'regex_replace: "the", "a"',
+     "And a people bowed and prayed To a neon god ay made"),
+    ("And the people bowed and prayed To the neon god they made",
+     'regex_replace: "THE ", "some "',
+     "And some people bowed and prayed To some neon god they made",),
+    ("And the people bowed and prayed To the neon god they made",
+     'regex_replace: regex="the", replace="some", count=1',
+     "And some people bowed and prayed To the neon god they made"),
+    (123412,
+     'regex_replace: "bar", "foo"',
+     123412),
 ])
 def test_single_filter(base, filter, result):
     tpl = f"{{{{ {base!r} | {filter} }}}}"
@@ -251,3 +263,25 @@ def test_dot():
     assert Liquid(
         "{{a | where: 'a-b', 1 | map: 'a-b' | first}}"
     ).render(a=[a, b]) == '1'
+
+def test_regex():
+    # Test case sensitivity
+    assert (
+        Liquid(
+            '{{ "And the people bowed and prayed To the neon god they made" | regex_replace: regex="and", replace="AND", case_sensitive=True }}'
+        ).render()
+        == "And the people bowed AND prayed To the neon god they made"
+    )
+    # Test capture groups
+    assert (
+        Liquid(
+            '{{ "And the people bowed and prayed To the neon god they made" | regex_replace: regex="([^ ]+ed) and ([^ ]+ed)", replace=repl }}'
+        ).render(repl=r"\2 and \1")
+        == "And the people prayed and bowed To the neon god they made"
+    )
+    assert (
+        Liquid(
+            '{{ "And the people bowed and prayed To the neon god they made" | regex_replace: regex=regex, replace=repl }}'
+        ).render(regex=r"(\w+ed) and (\w+ed)", repl="\\2 and \\1")
+        == "And the people prayed and bowed To the neon god they made"
+    )


### PR DESCRIPTION
This PR adds a regex_replace filter in similar vein to:
- https://github.com/joshdavenport/jekyll-regex-replace
- https://github.com/vduseev/liquid-regex

```python
from liquid import Liquid

# replace foo with bar
Liquid('{{ "foo_bar_foobar_barFOO" | regex_replace: regex="foo", replace="bar" }}').render() == 'bar_bar_barbar_barbar'
# replace foo with bar if at the beginning of the string
Liquid('{{ "foo_bar_foobar_barFOO" | regex_replace: regex="^foo", replace="bar" }}').render() == 'bar_bar_foobar_barFOO'
# replace first bar with foo
Liquid('{{ "foo_bar_foobar_barFOO" | regex_replace: regex="bar", replace="foo", count=1 }}').render() == 'foo_foo_foobar_barFOO'
# replace all bar with foo
Liquid('{{ "foo_bar_foobar_barFOO" | regex_replace: regex="bar", replace="foo" }}').render() == 'foo_foo_foofoo_fooFOO'
# Case sensitive 
Liquid('{{ "foo_bar_foobar_barFOO" | regex_replace: regex="FOO", replace="bar", case_sensitive=True }}').render() == 'foo_bar_foobar_barbar'
# Replace with captures
Liquid('{{ "foo_bar_foobar_barFOO" | regex_replace: regex="(.*foobar)_(.*)", replace=repl }}').render(repl="\\2_\\1") == 'barFOO_foo_bar_foobar'
Liquid('{{ "foo_bar_foobar_barFOO" | regex_replace: regex="(.*foobar)_(.*)", replace=repl }}').render(repl=r"\2_\1") == 'barFOO_foo_bar_foobar'
```